### PR TITLE
docs: add ClawCloud Run button

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,19 @@ English · [简体中文](./README_zh-CN.md) · [日本語](./README_ja-JP.md) �
 5. Click the address in **Use Now** on the details interface to enter the CoAI interface. The default username is `root` and the password is `chatnio123456` to log in to the backend management.
 6. For more operation details and payment information, see：[Service Details](https://computenest.console.aliyun.com/service/detail/ap-southeast-1/service-27e11d3a5c9b40628505/1?type=user&isRecommend=true).
 
+### ClawCloud Run (One-Click)
+[![Run on ClawCloud](https://raw.githubusercontent.com/ClawCloud/Run-Template/refs/heads/main/Run-on-ClawCloud.svg)](https://template.run.claw.cloud/?referralCode=WZVLKDWQ4CEA&openapp=system-fastdeploy%3FtemplateName%3Dchatnio)
+
+> ClawCloud Run is a cloud-native deployment platform where users can deploy the application with one click, we provide FREE $5 credits ervey month.
+
+1. Click `Run on ClawCloud` to navigate ClawCloud Run platform, and then select "Deploy App" to initiate the deployment process.
+
+2. Wait for the deployment to complete. Click "Details" to navigate the application details page, and use the provided "Public Address" to access ChatNio. The default username is `root` and the password is `chatnio123456`.
+
+3. To modify application configurations, click "Update" on top-right.
+
+4. For more information about ClawCloud Run, see [ClawCloud Run Docs](https://docs.run.claw.cloud/).
+
 
 ### ⚡ Docker Compose Installation (Recommended)
 > [!NOTE]

--- a/README_ja-JP.md
+++ b/README_ja-JP.md
@@ -96,6 +96,9 @@ English · [简体中文](./README_zh-CN.md) · [日本語](./README_ja-JP.md) �
 > 1. `Deploy` をクリックしてデプロイし、バインドしたいドメイン名を入力し、デプロイが完了するのを待ちます。
 > 2. デプロイが完了したら、ドメイン名にアクセスし、ユーザー名 `root` とパスワード `chatnio123456` を使用してバックエンド管理にログインします。チャットニオのバックエンドでパスワードを変更するように指示に従ってください。
 
+### ClawCloud Run (ワンクリック)
+[![Run on ClawCloud](https://raw.githubusercontent.com/ClawCloud/Run-Template/refs/heads/main/Run-on-ClawCloud.svg)](https://template.run.claw.cloud/?referralCode=WZVLKDWQ4CEA&openapp=system-fastdeploy%3FtemplateName%3Dchatnio)
+
 ### ⚡ Docker Composeインストール (推奨)
 > [!NOTE]
 > 実行が成功した後、ホストマシンのマッピングアドレスは `http://localhost:8000` です

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -114,6 +114,9 @@
 5. 点击详情界面**立即使用**中的链接，可进入CoAI社区版界面。默认用户名为`root`，密码`为chatnio123456` 登录后台管理。
 6. 更多操作详情与付费信息，参见：[服务详情](https://computenest.console.aliyun.com/service/detail/cn-hangzhou/service-bfbf676bd89d434691fc/1?type=user&isRecommend=true)
 
+### ClawCloud Run (一键部署)
+[![Run on ClawCloud](https://raw.githubusercontent.com/ClawCloud/Run-Template/refs/heads/main/Run-on-ClawCloud.svg)](https://template.run.claw.cloud/?referralCode=WZVLKDWQ4CEA&openapp=system-fastdeploy%3FtemplateName%3Dchatnio)
+
 ### ⚡ Docker Compose 安装 (推荐)
 > [!NOTE]
 > 运行成功后, 宿主机映射地址为 `http://localhost:8000`


### PR DESCRIPTION
docs: add ClawCloud Run button

---
We are **ClawCloud Run** — a cloud-native deployment platform where users can deploy your application with one click. The referral code in the deployment link is only for anonymous traffic analytics to help us improve our platform. If you’d like to use your own code, just sign up on ClawCloud Run and replace it in seconds.