### PR TITLE
fix: prevent path traversal in article download endpoints

### DIFF
--- a/addition/article/api.go
+++ b/addition/article/api.go
@@ -6,6 +6,7 @@ import (
 	"chat/utils"
 	"fmt"
 	"github.com/gin-gonic/gin"
+	"path/filepath"
 	"strings"
 )
 
@@ -24,14 +25,24 @@ type WebsocketArticleResponse struct {
 
 func ProjectTarDownloadAPI(c *gin.Context) {
 	hash := strings.TrimSpace(c.Query("hash"))
+	// Prevent path traversal by validating hash contains only safe characters
+	if hash == "" || strings.ContainsAny(hash, "/\..") {
+		c.JSON(400, gin.H{"error": "invalid hash"})
+		return
+	}
 	c.Writer.Header().Add("Content-Disposition", "attachment; filename=article.tar.gz")
-	c.File(fmt.Sprintf("storage/article/%s.tar.gz", hash))
+	c.File(filepath.Join("storage", "article", hash+".tar.gz"))
 }
 
 func ProjectZipDownloadAPI(c *gin.Context) {
 	hash := strings.TrimSpace(c.Query("hash"))
+	// Prevent path traversal by validating hash contains only safe characters
+	if hash == "" || strings.ContainsAny(hash, "/\..") {
+		c.JSON(400, gin.H{"error": "invalid hash"})
+		return
+	}
 	c.Writer.Header().Add("Content-Disposition", "attachment; filename=article.zip")
-	c.File(fmt.Sprintf("storage/article/%s.zip", hash))
+	c.File(filepath.Join("storage", "article", hash+".zip"))
 }
 
 func GenerateAPI(c *gin.Context) {


### PR DESCRIPTION
## Summary

Prevent path traversal in article download endpoints by validating the `hash` parameter.

## Problem

Both `ProjectTarDownloadAPI` and `ProjectZipDownloadAPI` use the `hash` query parameter directly in file path construction:

```go
hash := strings.TrimSpace(c.Query("hash"))
c.File(fmt.Sprintf("storage/article/%s.tar.gz", hash))
```

A crafted `hash` value with path traversal sequences can read arbitrary files:
- `?hash=../../etc/passwd` → reads `storage/article/../../etc/passwd.tar.gz`
- With `..` sequences, an attacker can escape the `storage/article/` directory

## Fix

1. Validate `hash` doesn't contain path separators or `..` sequences
2. Use `filepath.Join` for safe path construction
3. Return 400 error for invalid hash values

## Impact

- **Type**: Path Traversal / Arbitrary File Read (CWE-22)
- **Affected endpoints**: `/article/tar`, `/article/zip`
- **Risk**: Read arbitrary files on the server
- **OWASP**: A01:2021 — Broken Access Control