### PR TITLE
fix: add missing remove and update endpoints for broadcast announcements

### DIFF
--- a/manager/broadcast/controller.go
+++ b/manager/broadcast/controller.go
@@ -4,6 +4,7 @@ import (
 	"chat/auth"
 	"github.com/gin-gonic/gin"
 	"net/http"
+	"strconv"
 )
 
 func ViewBroadcastAPI(c *gin.Context) {
@@ -54,5 +55,62 @@ func GetBroadcastListAPI(c *gin.Context) {
 
 	c.JSON(http.StatusOK, listResponse{
 		Data: data,
+	})
+}
+
+func RemoveBroadcastAPI(c *gin.Context) {
+	user := auth.RequireAdmin(c)
+	if user == nil {
+		return
+	}
+
+	indexStr := c.Param("index")
+	index, err := strconv.Atoi(indexStr)
+	if err != nil {
+		c.JSON(http.StatusOK, createResponse{
+			Status: false,
+			Error:  "invalid index",
+		})
+		return
+	}
+
+	if err := removeBroadcast(c, index); err != nil {
+		c.JSON(http.StatusOK, createResponse{
+			Status: false,
+			Error:  err.Error(),
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, createResponse{
+		Status: true,
+	})
+}
+
+func UpdateBroadcastAPI(c *gin.Context) {
+	user := auth.RequireAdmin(c)
+	if user == nil {
+		return
+	}
+
+	var form updateRequest
+	if err := c.ShouldBindJSON(&form); err != nil {
+		c.JSON(http.StatusOK, createResponse{
+			Status: false,
+			Error:  err.Error(),
+		})
+		return
+	}
+
+	if err := updateBroadcast(c, form.ID, form.Content); err != nil {
+		c.JSON(http.StatusOK, createResponse{
+			Status: false,
+			Error:  err.Error(),
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, createResponse{
+		Status: true,
 	})
 }

--- a/manager/broadcast/manage.go
+++ b/manager/broadcast/manage.go
@@ -47,3 +47,29 @@ func getBroadcastList(c *gin.Context) ([]Info, error) {
 
 	return broadcastList, nil
 }
+
+func removeBroadcast(c *gin.Context, index int) error {
+	db := utils.GetDBFromContext(c)
+	cache := utils.GetCacheFromContext(c)
+
+	if _, err := globals.ExecDb(db, `DELETE FROM broadcast WHERE id = ?`, index); err != nil {
+		return err
+	}
+
+	cache.Del(context.Background(), ":broadcast")
+
+	return nil
+}
+
+func updateBroadcast(c *gin.Context, index int, content string) error {
+	db := utils.GetDBFromContext(c)
+	cache := utils.GetCacheFromContext(c)
+
+	if _, err := globals.ExecDb(db, `UPDATE broadcast SET content = ? WHERE id = ?`, content, index); err != nil {
+		return err
+	}
+
+	cache.Del(context.Background(), ":broadcast")
+
+	return nil
+}

--- a/manager/broadcast/router.go
+++ b/manager/broadcast/router.go
@@ -6,4 +6,6 @@ func Register(app *gin.RouterGroup) {
 	app.GET("/broadcast/view", ViewBroadcastAPI)
 	app.GET("/broadcast/list", GetBroadcastListAPI)
 	app.POST("/broadcast/create", CreateBroadcastAPI)
+	app.POST("/broadcast/remove/:index", RemoveBroadcastAPI)
+	app.POST("/broadcast/update", UpdateBroadcastAPI)
 }

--- a/manager/broadcast/types.go
+++ b/manager/broadcast/types.go
@@ -20,6 +20,11 @@ type createRequest struct {
 	Content string `json:"content"`
 }
 
+type updateRequest struct {
+	ID      int    `json:"id"`
+	Content string `json:"content"`
+}
+
 type createResponse struct {
 	Status bool   `json:"status"`
 	Error  string `json:"error"`


### PR DESCRIPTION
Fixes #390

## Problem

The admin broadcast management panel's Delete and Edit operations always failed with a request failed error. The frontend sends:
- POST /broadcast/remove/:index to delete a broadcast
- POST /broadcast/update with { id, content } to update a broadcast

However, the backend router only registered three endpoints: view, list, and create. The missing remove and update endpoints caused 404 responses.

## Solution

Added the two missing backend endpoints:
1. removeBroadcast in manage.go - executes DELETE FROM broadcast WHERE id = ? and invalidates the cache
2. updateBroadcast in manage.go - executes UPDATE broadcast SET content = ? WHERE id = ? and invalidates the cache
3. RemoveBroadcastAPI and UpdateBroadcastAPI handlers in controller.go
4. Added updateRequest type in types.go
5. Registered both routes in router.go

## Testing

Manually traced the frontend API calls in app/src/api/broadcast.ts against the backend route table to confirm the mismatch. The fix mirrors the established patterns used by createBroadcast and getBroadcastList.