### PR TITLE
fix: skip frequency_penalty and presence_penalty for XAI grok reasoning models

### DIFF
--- a/adapter/openai/chat.go
+++ b/adapter/openai/chat.go
@@ -49,6 +49,10 @@ func (c *ChatInstance) GetChatBody(props *adaptercommon.ChatProps, stream bool) 
 	// o1, o3, gpt-5 compatibility
 	isNewModel := len(props.Model) >= 2 && (props.Model[:2] == "o1" || props.Model[:2] == "o3") || strings.HasPrefix(props.Model, "gpt-5")
 
+	// XAI grok reasoning models (e.g. grok-3-mini, grok-3-mini-fast) do not support
+	// frequency_penalty or presence_penalty and return HTTP 400 when these are sent.
+	isGrokReasoningModel := strings.HasPrefix(props.Model, "grok-") && strings.Contains(props.Model, "-mini")
+
 	var temperature *float32
 	if isNewModel {
 		temp := float32(1.0)
@@ -57,12 +61,19 @@ func (c *ChatInstance) GetChatBody(props *adaptercommon.ChatProps, stream bool) 
 		temperature = props.Temperature
 	}
 
+	var presencePenalty *float32
+	var frequencyPenalty *float32
+	if !isGrokReasoningModel {
+		presencePenalty = props.PresencePenalty
+		frequencyPenalty = props.FrequencyPenalty
+	}
+
 	request := ChatRequest{
 		Model:            props.Model,
 		Messages:         messages,
 		Stream:           stream,
-		PresencePenalty:  props.PresencePenalty,
-		FrequencyPenalty: props.FrequencyPenalty,
+		PresencePenalty:  presencePenalty,
+		FrequencyPenalty: frequencyPenalty,
 		Temperature:      temperature,
 		TopP:             props.TopP,
 		Tools:            props.Tools,


### PR DESCRIPTION
Fixes #374

## Problem

XAI's grok reasoning models (e.g. `grok-3-mini`, `grok-3-mini-fast`) do not support the `frequency_penalty` and `presence_penalty` parameters. When users configure an XAI channel using the OpenAI-compatible adapter and select a thinking/reasoning model, the request always includes these parameters, causing the XAI API to return HTTP 400.

## Solution

Detect grok reasoning models by their naming pattern (`grok-` prefix + `-mini` substring) and omit `frequency_penalty` and `presence_penalty` from the request body for these models. Since both fields are tagged `omitempty` in `ChatRequest`, setting them to `nil` ensures they are not serialized.

This follows the same pattern already used for `o1`/`o3`/`gpt-5` models where unsupported parameters are conditionally excluded.

## Testing

- Verified `gofmt` and `go build` pass with no errors.
- The change is limited to `GetChatBody` in `adapter/openai/chat.go` and only affects models matching the grok reasoning model pattern.